### PR TITLE
Added API request functions

### DIFF
--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -102,15 +102,6 @@ var sign = function(msg, keyPair) {
   return { hash: hsh, sig: binToHex(sigBin), pubKey: keyPair.publicKey };
 };
 
-var pullSigAndPubKey = function(s) {
-  if (!s.hasOwnProperty("pubKey") || !s.hasOwnProperty("sig")) {
-    throw new TypeError(
-      "Expected to find keys of name 'sig' and 'pubKey' in " + JSON.stringify(s)
-    );
-  }
-  return { sig: s.sig, pubKey: s.pubKey };
-};
-
 var pullSig = function(s) {
   if (!s.hasOwnProperty("sig")) {
     throw new TypeError(
@@ -118,15 +109,6 @@ var pullSig = function(s) {
     );
   }
   return { sig: s.sig };
-};
-
-var pullPubKeyAndAddr = function(s) {
-  if (!s.hasOwnProperty("pubKey")) {
-    throw new TypeError(
-      "Expected to find keys of name 'pubKey' in " + JSON.stringify(s)
-    );
-  }
-  return { pubKey: s.pubKey, addr: s.pubKey, scheme: "ED25519" };
 };
 
 var pullAndCheckHashs = function(sigs) {
@@ -223,14 +205,14 @@ var asArray = function(singleOrArray) {
 var enforceType = function(val, type, msg) {
   if (typeof val !== type) {
     throw new TypeError(
-      msg + " must be a " + type + ": " + JSON.stringify(value)
+      msg + " must be a " + type + ": " + JSON.stringify(val)
     );
   }
 };
 
 var enforceArray = function(val, msg) {
   if (!Array.isArray(val)) {
-    throw new TypeError(msg + " must be an array: " + JSON.stringify(value));
+    throw new TypeError(msg + " must be an array: " + JSON.stringify(val));
   }
 };
 
@@ -239,17 +221,6 @@ var enforceArray = function(val, msg) {
  */
 var simpleExecCommand = function(keyPairs, nonce, pactCode, envData, meta) {
   return mkPublicSend(prepareExecCmd(keyPairs, nonce, pactCode, envData, meta));
-};
-
-var unique = function(arr) {
-  var n = {},
-    r = [];
-  for (var i = 0; i < arr.length; i++) var hsh = eckHashs(sigs);
-  return mkPublicSend({
-    hash: hsh,
-    sigs: sigs.map(pullSigAndPubKey),
-    cmd: cmd
-  });
 };
 
 var unique = function(arr) {

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -317,7 +317,7 @@ var mkReq = function (cmd) {
 };
 
 /**
- * Sends Pact command to running Pact server and retrieves tx result.
+ * Sends Pact command to a running Pact server and retrieves tx result.
  * @param {Object}
  * @property pactCode {string} - pact code to execute
  * @property keyPairs {array or object} - array or single ED25519 keypair
@@ -328,13 +328,35 @@ var mkReq = function (cmd) {
  * @return {object} - tx result received from pact server.
  */
 const sendCommand = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
-  const reqParams = ["pactCode", "keyPairs", "meta", "apiHost"]
+  const reqParams = ["pactCode", "keyPairs", "apiHost"]
   reqParams.forEach(arg => {
-    if (!arguments[0][arg])  throw new Error (`Pact.sendCommand(): No ${arg} provided`)
+    if (!arguments[0][arg]) throw new Error (`Pact.sendCommand(): No ${arg} provided`)
   })
   const cmd = simpleExecCommand(keyPairs, nonce, pactCode, envData, meta);
   const res = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
   const txRes = await fetch(`${apiHost}/api/v1/listen`, mkReq(simpleListenRequestFromExec(cmd)));
+  const tx = await txRes.json();
+  return tx.result;
+};
+
+/**
+ * Sends Local Pact command to a running Pact server and retrieves local tx result.
+ * @param {Object}
+ * @property pactCode {string} - pact code to execute
+ * @property keyPairs {array or object} - array or single ED25519 keypair
+ * @property nonce {string} - nonce value, default at current time
+ * @property envData {object} - JSON message data for command, default at empty obj
+ * @property meta {object} - meta information, see mkMeta
+ * @property apiHost {string} - host running Pact server
+ * @return {object} - tx result received from pact server.
+ */
+const sendLocalCommand = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
+  const reqParams = ["pactCode", "keyPairs", "apiHost"]
+  reqParams.forEach(arg => {
+    if (!arguments[0][arg])  throw new Error (`Pact.sendCommand(): No ${arg} provided`)
+  })
+  const cmd = simpleLocalCommand(keyPairs, nonce, pactCode, envData, meta);
+  const txRes = await fetch(`${apiHost}/api/v1/local`, mkReq(cmd));
   const tx = await txRes.json();
   return tx.result;
 };
@@ -366,5 +388,6 @@ module.exports = {
       createListenRequest: simpleListenRequestFromExec
     }
   },
-  sendCommand: sendCommand
+  sendCommand: sendCommand,
+  sendLocalCommand: sendLocalCommand
 };

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -4,9 +4,9 @@
  * Supports: Pact API 3.0 v1
  */
 
-const blake = require('blakejs');
-const nacl = require('tweetnacl');
-const base64url = require('base64-url');
+const blake = require("blakejs");
+const nacl = require("tweetnacl");
+const base64url = require("base64-url");
 
 /**
  * Convert binary to hex.
@@ -16,12 +16,12 @@ const base64url = require('base64-url');
 var binToHex = function(s) {
   var constructor = s.constructor.name || null;
 
-  if (constructor !== 'Uint8Array') {
-    throw new TypeError('Expected Uint8Array');
+  if (constructor !== "Uint8Array") {
+    throw new TypeError("Expected Uint8Array");
   }
 
-  return Buffer.from(s).toString('hex');
-}
+  return Buffer.from(s).toString("hex");
+};
 
 /**
  * Convert hex string to binary.
@@ -29,30 +29,32 @@ var binToHex = function(s) {
  * @return {Uint8Array} binary value
  */
 var hexToBin = function(h) {
-  if (typeof h !== 'string') { throw new TypeError("Expected string: " + h); }
-  return new Uint8Array(Buffer.from(h,'hex'));
-}
+  if (typeof h !== "string") {
+    throw new TypeError("Expected string: " + h);
+  }
+  return new Uint8Array(Buffer.from(h, "hex"));
+};
 
 /**
  * Perform blake2b256 hashing.
  */
 var hashBin = function(s) {
   return blake.blake2b(s, null, 32);
-}
+};
 
 /**
  * Perform blake2b256 hashing, encoded as unescaped base64url.
  */
 var hash = function(s) {
   return base64UrlEncode(hashBin(s));
-}
+};
 
 /**
  * Hash string as unescaped base64url.
  */
 var base64UrlEncode = function(s) {
   return base64url.escape(base64url.encode(s));
-}
+};
 
 /**
  * Generate a random ED25519 keypair.
@@ -61,18 +63,22 @@ var base64UrlEncode = function(s) {
 var genKeyPair = function() {
   var kp = nacl.sign.keyPair();
   var pubKey = binToHex(kp.publicKey);
-  var secKey = binToHex(kp.secretKey).slice(0,64);
-  return {"publicKey": pubKey, "secretKey": secKey};
-}
+  var secKey = binToHex(kp.secretKey).slice(0, 64);
+  return { publicKey: pubKey, secretKey: secKey };
+};
 
 var toTweetNaclSecretKey = function(keyPair) {
-  if (!keyPair.hasOwnProperty("publicKey") || !keyPair.hasOwnProperty("secretKey") ) {
-    throw new TypeError
-    ("Invalid KeyPair: expected to find keys of name 'secretKey' and 'publicKey': " +
-     JSON.stringify(keyPair));
+  if (
+    !keyPair.hasOwnProperty("publicKey") ||
+    !keyPair.hasOwnProperty("secretKey")
+  ) {
+    throw new TypeError(
+      "Invalid KeyPair: expected to find keys of name 'secretKey' and 'publicKey': " +
+        JSON.stringify(keyPair)
+    );
   }
   return hexToBin(keyPair.secretKey + keyPair.publicKey);
-}
+};
 
 /**
  * Sign data using key pair.
@@ -81,48 +87,59 @@ var toTweetNaclSecretKey = function(keyPair) {
  * @return {object} with "hash", "sig" (signature in hex format), and "pubKey" public key value.
  */
 var sign = function(msg, keyPair) {
-  if (!keyPair.hasOwnProperty("publicKey") || !keyPair.hasOwnProperty("secretKey") ) {
-    throw new TypeError("Invalid KeyPair: expected to find keys of name 'secretKey' and 'publicKey': " + JSON.stringify(keyPair));
+  if (
+    !keyPair.hasOwnProperty("publicKey") ||
+    !keyPair.hasOwnProperty("secretKey")
+  ) {
+    throw new TypeError(
+      "Invalid KeyPair: expected to find keys of name 'secretKey' and 'publicKey': " +
+        JSON.stringify(keyPair)
+    );
   }
   var hshBin = hashBin(msg);
   var hsh = base64UrlEncode(hshBin);
   var sigBin = nacl.sign.detached(hshBin, toTweetNaclSecretKey(keyPair));
-  return {"hash": hsh, "sig": binToHex(sigBin), "pubKey":keyPair.publicKey};
-}
+  return { hash: hsh, sig: binToHex(sigBin), pubKey: keyPair.publicKey };
+};
 
 var pullSigAndPubKey = function(s) {
   if (!s.hasOwnProperty("pubKey") || !s.hasOwnProperty("sig")) {
-    throw new TypeError("Expected to find keys of name 'sig' and 'pubKey' in " + JSON.stringify(s));
+    throw new TypeError(
+      "Expected to find keys of name 'sig' and 'pubKey' in " + JSON.stringify(s)
+    );
   }
-  return {"sig":s.sig, "pubKey":s.pubKey};
-}
-
+  return { sig: s.sig, pubKey: s.pubKey };
+};
 
 var pullSig = function(s) {
   if (!s.hasOwnProperty("sig")) {
-    throw new TypeError("Expected to find keys of name 'sig' in " + JSON.stringify(s));
+    throw new TypeError(
+      "Expected to find keys of name 'sig' in " + JSON.stringify(s)
+    );
   }
-  return {"sig":s.sig};
-}
+  return { sig: s.sig };
+};
 
 var pullPubKeyAndAddr = function(s) {
   if (!s.hasOwnProperty("pubKey")) {
-    throw new TypeError("Expected to find keys of name 'pubKey' in " + JSON.stringify(s));
+    throw new TypeError(
+      "Expected to find keys of name 'pubKey' in " + JSON.stringify(s)
+    );
   }
-  return {"pubKey":s.pubKey, "addr":s.pubKey, "scheme": "ED25519"};
-}
-
+  return { pubKey: s.pubKey, addr: s.pubKey, scheme: "ED25519" };
+};
 
 var pullAndCheckHashs = function(sigs) {
   var hsh = sigs[0].hash;
-  for(var i = 1; i < sigs.length; i++)
-  {
-    if(sigs[i].hash !== hsh) {
-      throw new Error('Sigs for different hashes found: ' + JSON.stringify(sigs));
+  for (var i = 1; i < sigs.length; i++) {
+    if (sigs[i].hash !== hsh) {
+      throw new Error(
+        "Sigs for different hashes found: " + JSON.stringify(sigs)
+      );
     }
   }
   return hsh;
-}
+};
 
 /**
  * Prepare an ExecMsg pact command for use in send or local execution.
@@ -135,27 +152,28 @@ var pullAndCheckHashs = function(sigs) {
  * @return valid pact API command for send or local use.
  */
 var prepareExecCmd = function(keyPairs, nonce, pactCode, envData, meta) {
-
-  enforceType(nonce,'string','nonce');
-  enforceType(pactCode,'string','pactCode');
+  enforceType(nonce, "string", "nonce");
+  enforceType(pactCode, "string", "pactCode");
 
   var kpArray = asArray(keyPairs);
   var signers = kpArray.map(mkSigner);
-  var cmdJSON =
-      { "nonce": nonce,
-        "payload": {
-          "exec": {
-            "code": pactCode,
-            "data": envData || {}
-          }
-        },
-        "signers": signers,
-        "meta": meta
-      };
+  var cmdJSON = {
+    nonce: nonce,
+    payload: {
+      exec: {
+        code: pactCode,
+        data: envData || {}
+      }
+    },
+    signers: signers,
+    meta: meta
+  };
   var cmd = JSON.stringify(cmdJSON);
-  var sigs = kpArray.map(function(kp) { return sign(cmd, kp); });
-  return mkSingleCmd(sigs,cmd);
-}
+  var sigs = kpArray.map(function(kp) {
+    return sign(cmd, kp);
+  });
+  return mkSingleCmd(sigs, cmd);
+};
 
 /**
  * Makes a single command given signed data.
@@ -164,20 +182,22 @@ var prepareExecCmd = function(keyPairs, nonce, pactCode, envData, meta) {
  * @return valid Pact API command for send or local use.
  */
 var mkSingleCmd = function(sigs, cmd) {
-  enforceArray(sigs,"sigs");
-  enforceType(cmd,'string','cmd');
-  return { "hash": pullAndCheckHashs(sigs)
-           , "sigs": sigs.map(pullSig)
-           , "cmd": cmd };
-}
+  enforceArray(sigs, "sigs");
+  enforceType(cmd, "string", "cmd");
+  return {
+    hash: pullAndCheckHashs(sigs),
+    sigs: sigs.map(pullSig),
+    cmd: cmd
+  };
+};
 
 /**
  * Makes outer wrapper for a 'send' endpoint.
  * @param {array or object} cmds - one or an array of commands, see mkSingleCmd
  */
 var mkPublicSend = function(cmds) {
-  return { "cmds": asArray(cmds) };
-}
+  return { cmds: asArray(cmds) };
+};
 
 /**
  * Make an ED25519 "signer" array element for inclusion in a Pact payload.
@@ -186,11 +206,11 @@ var mkPublicSend = function(cmds) {
  */
 var mkSigner = function(kp) {
   return {
-    "pubKey": kp.publicKey,
-    "addr": kp.publicKey,
-    "scheme": "ED25519"
-  }
-}
+    pubKey: kp.publicKey,
+    addr: kp.publicKey,
+    scheme: "ED25519"
+  };
+};
 
 var asArray = function(singleOrArray) {
   if (Array.isArray(singleOrArray)) {
@@ -198,46 +218,51 @@ var asArray = function(singleOrArray) {
   } else {
     return [singleOrArray];
   }
-}
+};
 
-var enforceType = function(val,type,msg) {
+var enforceType = function(val, type, msg) {
   if (typeof val !== type) {
-    throw new TypeError(msg + ' must be a ' + type + ': ' + JSON.stringify(value));
+    throw new TypeError(
+      msg + " must be a " + type + ": " + JSON.stringify(value)
+    );
   }
-}
+};
 
-var enforceArray = function(val,msg) {
+var enforceArray = function(val, msg) {
   if (!Array.isArray(val)) {
-    throw new TypeError(msg + ' must be an array: ' + JSON.stringify(value));
+    throw new TypeError(msg + " must be an array: " + JSON.stringify(value));
   }
-}
+};
 
 /**
  * Make a full 'send' endpoint exec command. See 'prepareExecCmd' for parameters.
  */
 var simpleExecCommand = function(keyPairs, nonce, pactCode, envData, meta) {
   return mkPublicSend(prepareExecCmd(keyPairs, nonce, pactCode, envData, meta));
-}
+};
 
 var unique = function(arr) {
-  var n = {},r=[];
-  for(var i = 0; i < arr.length; i++)
-  var hsh = eckHashs(sigs);
-  return mkPublicSend({"hash": hsh, "sigs":sigs.map(pullSigAndPubKey), "cmd":cmd});
-}
+  var n = {},
+    r = [];
+  for (var i = 0; i < arr.length; i++) var hsh = eckHashs(sigs);
+  return mkPublicSend({
+    hash: hsh,
+    sigs: sigs.map(pullSigAndPubKey),
+    cmd: cmd
+  });
+};
 
 var unique = function(arr) {
-  var n = {},r=[];
-  for(var i = 0; i < arr.length; i++)
-  {
-    if (!n[arr[i]])
-    {
+  var n = {},
+    r = [];
+  for (var i = 0; i < arr.length; i++) {
+    if (!n[arr[i]]) {
       n[arr[i]] = true;
       r.push(arr[i]);
     }
   }
   return r;
-}
+};
 
 /**
  * Given an exec 'send' message, prepare a message for 'poll' endpoint.
@@ -245,15 +270,28 @@ var unique = function(arr) {
  * @return {object} with "requestKeys" for polling.
  */
 var simplePollRequestFromExec = function(execMsg) {
-  var cmds = execMsg.cmds || TypeError("expected key 'cmds' in object: " + JSON.stringify(execMsg));
+  var cmds =
+    execMsg.cmds ||
+    TypeError("expected key 'cmds' in object: " + JSON.stringify(execMsg));
   var rks = [];
-  if (!cmds.every(function(v){return v.hasOwnProperty("hash");})) {
-    throw new TypeError('maleformed object, expected "hash" key in every cmd: ' + JSON.stringify(execMsg));
+  if (
+    !cmds.every(function(v) {
+      return v.hasOwnProperty("hash");
+    })
+  ) {
+    throw new TypeError(
+      'maleformed object, expected "hash" key in every cmd: ' +
+        JSON.stringify(execMsg)
+    );
   } else {
-    rks = unique(cmds.map(function(v){return v.hash;}));
+    rks = unique(
+      cmds.map(function(v) {
+        return v.hash;
+      })
+    );
   }
-  return {"requestKeys": rks};
-}
+  return { requestKeys: rks };
+};
 
 /**
  * Given an exec 'send' message, prepare a message for 'listen' endpoint.
@@ -261,24 +299,46 @@ var simplePollRequestFromExec = function(execMsg) {
  * @return {object} with "requestKey" for polling.
  */
 var simpleListenRequestFromExec = function(execMsg) {
-  var cmds = execMsg.cmds || TypeError("expected key 'cmds' in object: " + JSON.stringify(execMsg));
+  var cmds =
+    execMsg.cmds ||
+    TypeError("expected key 'cmds' in object: " + JSON.stringify(execMsg));
   var rks = [];
-  if (!cmds.every(function(v){return v.hasOwnProperty("hash");})) {
-    throw new TypeError('maleformed object, expected "hash" key in every cmd: ' + JSON.stringify(execMsg));
+  if (
+    !cmds.every(function(v) {
+      return v.hasOwnProperty("hash");
+    })
+  ) {
+    throw new TypeError(
+      'maleformed object, expected "hash" key in every cmd: ' +
+        JSON.stringify(execMsg)
+    );
   } else {
-    rks = unique(cmds.map(function(v){return v.hash;}));
+    rks = unique(
+      cmds.map(function(v) {
+        return v.hash;
+      })
+    );
   }
-  return {"listen": rks[0]};
-}
+  return { listen: rks[0] };
+};
 
 /**
  * Variadic function to form a lisp s-expression application.
  * Encases arguments in parens and intercalates with a space.
  */
 var mkExp = function(pgmName) {
-  enforceType(pgmName, "string", "pgmName")
-  return '(' + pgmName + ' ' + Array.prototype.slice.call(arguments, 1).map(JSON.stringify).join(' ') + ')';
-}
+  enforceType(pgmName, "string", "pgmName");
+  return (
+    "(" +
+    pgmName +
+    " " +
+    Array.prototype.slice
+      .call(arguments, 1)
+      .map(JSON.stringify)
+      .join(" ") +
+    ")"
+  );
+};
 
 /**
  * Prepare a chainweb-style meta payload.
@@ -288,70 +348,90 @@ var mkExp = function(pgmName) {
  * @param gasLimit {number} desired gas limit
  * @return {object} of arguments, type-checked and properly named.
  */
-var mkMeta = function (sender, chainId, gasPrice, gasLimit) {
+var mkMeta = function(sender, chainId, gasPrice, gasLimit) {
   enforceType(sender, "string", "sender");
   enforceType(chainId, "string", "chainId");
   enforceType(gasPrice, "number", "gasPrice");
   enforceType(gasPrice, "number", "gasLimit");
-  return { "gasLimit":gasLimit, "chainId":chainId, "gasPrice":gasPrice, "sender":sender }
-}
+  return {
+    gasLimit: gasLimit,
+    chainId: chainId,
+    gasPrice: gasPrice,
+    sender: sender
+  };
+};
 
 /**
  * Formats ExecCmd into api request object
  */
-var mkReq = function (cmd) {
+var mkReq = function(cmd) {
   return {
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json"
     },
-    method: 'POST',
-    body: JSON.stringify(cmd),
-  }
-}
+    method: "POST",
+    body: JSON.stringify(cmd)
+  };
+};
 
 /**
- * Sends Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
+ * A Command Object
+ * @typedef {Object} ExecCmd
  * @property pactCode {string} - pact code to execute
  * @property keyPairs {array or object} - array or single ED25519 keypair
  * @property nonce {string} - nonce value, default at current time
  * @property envData {object} - JSON message data for command, default at empty obj
  * @property meta {object} - meta information, see mkMeta
  * @property apiHost {string} - host running Pact server
+ */
+
+/**
+ * Sends Pact command to a running Pact server and retrieves tx result.
+ * @param {ExecCmd} SendCmd
  * @return {object} - Request key of the tx received from pact server.
  */
-const fetchSend = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
-  const reqParams = ["pactCode", "keyPairs", "apiHost"]
+const fetchSend = async function({
+  pactCode,
+  keyPairs,
+  nonce = new Date().toISOString(),
+  envData = {},
+  meta = mkMeta("", "", 0, 0),
+  apiHost
+}) {
+  const reqParams = ["pactCode", "keyPairs", "apiHost"];
   reqParams.forEach(arg => {
-    if (!arguments[0][arg]) throw new Error (`Pact.sendCommand(): No ${arg} provided`)
-  })
+    if (!arguments[0][arg])
+      throw new Error(`Pact.sendCommand(): No ${arg} provided`);
+  });
   const cmd = simpleExecCommand(keyPairs, nonce, pactCode, envData, meta);
   const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
   const tx = await txRes.json();
   return tx;
-}
+};
 
 /**
  * Sends Local Pact command to a running Pact server and retrieves local tx result.
- * @param {Object}
- * @property pactCode {string} - pact code to execute
- * @property keyPairs {array or object} - array or single ED25519 keypair
- * @property nonce {string} - nonce value, default at current time
- * @property envData {object} - JSON message data for command, default at empty obj
- * @property meta {object} - meta information, see mkMeta
- * @property apiHost {string} - host running Pact server
+ * @param {ExecCmd} LocalCmd
  * @return {object} - tx result received from pact server.
  */
-const fetchLocal = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
-  const reqParams = ["pactCode", "keyPairs", "apiHost"]
+const fetchLocal = async function({
+  pactCode,
+  keyPairs,
+  nonce = new Date().toISOString(),
+  envData = {},
+  meta = mkMeta("", "", 0, 0),
+  apiHost
+}) {
+  const reqParams = ["pactCode", "keyPairs", "apiHost"];
   reqParams.forEach(arg => {
-    if (!arguments[0][arg])  throw new Error (`Pact.sendCommand(): No ${arg} provided`)
-  })
+    if (!arguments[0][arg])
+      throw new Error(`Pact.sendCommand(): No ${arg} provided`);
+  });
   const cmd = prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
   const txRes = await fetch(`${apiHost}/api/v1/local`, mkReq(cmd));
   const tx = await txRes.json();
   return tx.result;
-}
+};
 
 /**
  * Request poll Pact command to a running Pact server and retrieves tx result.
@@ -359,15 +439,15 @@ const fetchLocal = async function ({pactCode, keyPairs, nonce=new Date().toISOSt
  * @property rks {array} - Array of request keys of tx to poll.
  * @property apiHost {string} - host running Pact server
  * @return {object} - Array of tx request keys and tx results from pact server.
-*/
-const fetchPoll = async function ({rks, apiHost}) {
-  const cmd = { "requestKeys": rks }
+ */
+const fetchPoll = async function({ rks, apiHost }) {
+  const cmd = { requestKeys: rks };
   const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(cmd));
   const resJSON = await res.json();
   return Object.values(resJSON).map(res => {
     return { reqKey: res.reqKey, result: res.result };
-  })
-}
+  });
+};
 
 /**
  * Request listen Pact command to a running Pact server and retrieves tx result.
@@ -375,13 +455,13 @@ const fetchPoll = async function ({rks, apiHost}) {
  * @property rk {string} - reqest key of tx to listen.
  * @property apiHost {string} - host running Pact server
  * @return {object} - Object containing tx result from pact server
-*/
-const fetchListen = async function ({rk, apiHost}) {
-  const cmd = { "listen": rk }
+ */
+const fetchListen = async function({ rk, apiHost }) {
+  const cmd = { listen: rk };
   const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(cmd));
   const resJSON = await res.json();
   return resJSON.result;
-}
+};
 
 module.exports = {
   crypto: {
@@ -416,4 +496,4 @@ module.exports = {
     poll: fetchPoll,
     listen: fetchListen
   }
-}
+};

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -385,7 +385,6 @@ var mkReq = function(cmd) {
  */
 
 /**
-<<<<<<< HEAD
  * Sends Pact command to a running Pact server and retrieves tx result.
  * @param {[execCmd] or execCmd} sendCmd cmd or a list of cmd's to execute
  * @param {string} apiHost host running Pact server
@@ -395,48 +394,18 @@ const fetchSend = async function(sendCmd, apiHost){
   if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
   const sendCmds = asArray(sendCmd).map(cmd => prepareExecCmd(cmd.keyPairs, cmd.nonce, cmd.pactCode, cmd.envData, cmd.meta));
   const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(mkPublicSend(sendCmds)));
-=======
- * A Command Object to be received to send cmd to Pact server.
- * @typedef {Object} execCmd
- * @property pactCode {string} - pact code to execute
- * @property keyPairs {array or object} - array or single ED25519 keypair
- * @property nonce {string} - nonce value, default at current time
- * @property envData {object} - JSON message data for command, default at empty obj
- * @property meta {object} - meta information, see mkMeta
- * @property apiHost {string} - host running Pact server
- */
-
- /**
-  * Sends Pact command to a running Pact server and retrieves the tx's request key.
-  * @param {execCmd} sendCmd
-  * @return {object} - Request key of the tx received from pact server.
-  */
-const fetchSend = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
-  const reqParams = ["pactCode", "keyPairs", "apiHost"]
-  reqParams.forEach(arg => {
-    if (!arguments[0][arg]) throw new Error (`Pact.sendCommand(): No ${arg} provided`)
-  })
-  const cmd = simpleExecCommand(keyPairs, nonce, pactCode, envData, meta);
-  const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
->>>>>>> b4aa797beec41087871489310786570c91999f08
   const tx = await txRes.json();
   return tx;
 };
 
 /**
-<<<<<<< HEAD
  * Sends Local Pact command to a local Pact server and retrieves local tx result.
  * @param {execCmd} localCmd a single cmd to execute locally
  * @param {string} apiHost host running Pact server
  * @return {object} tx result received from pact server.
-=======
- * Sends Local Pact command to a running Pact server and retrieves local tx result.
- * @param {execCmd} localCmd
- * @return {object} - tx result received from pact server.
->>>>>>> b4aa797beec41087871489310786570c91999f08
  */
 const fetchLocal = async function(localCmd, apiHost) {
-  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  if (!apiHost)  throw new Error(`Pact.fetch.local(): No apiHost provided`);
   const {keyPairs, nonce, pactCode, envData, meta} = localCmd
   const cmd = prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
   const txRes = await fetch(`${apiHost}/api/v1/local`, mkReq(cmd));
@@ -446,24 +415,13 @@ const fetchLocal = async function(localCmd, apiHost) {
 
 /**
  * Request poll Pact command to a running Pact server and retrieves tx result.
-<<<<<<< HEAD
  * @param {{requestKeys: [<rk:string>]}} pollCmd request Keys of txs to poll.
  * @param {string} apiHost host running Pact server
  * @return {object} Array of tx request keys and tx results from pact server.
  */
 const fetchPoll = async function(pollCmd, apiHost) {
-  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  if (!apiHost)  throw new Error(`Pact.fetch.poll(): No apiHost provided`);
   const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(pollCmd));
-=======
- * @param {Object} pollCmd
- * @property rks {array} - Array of request keys of tx to poll.
- * @property apiHost {string} - host running Pact server
- * @return {object} - Array of tx request keys and tx results from pact server.
-*/
-const fetchPoll = async function ({rks, apiHost}) {
-  const cmd = { "requestKeys": rks }
-  const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(cmd));
->>>>>>> b4aa797beec41087871489310786570c91999f08
   const resJSON = await res.json();
   return Object.values(resJSON).map(res => {
     return { reqKey: res.reqKey, result: res.result };
@@ -472,24 +430,13 @@ const fetchPoll = async function ({rks, apiHost}) {
 
 /**
  * Request listen Pact command to a running Pact server and retrieves tx result.
-<<<<<<< HEAD
  * @param {{listenCmd: <rk:string>}} listenCmd reqest key of tx to listen.
  * @param {string} apiHost host running Pact server
  * @return {object} Object containing tx result from pact server
  */
 const fetchListen = async function(listenCmd, apiHost) {
-  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  if (!apiHost)  throw new Error(`Pact.fetch.listen(): No apiHost provided`);
   const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(listenCmd));
-=======
- * @param {Object} listenCmd
- * @property rk {string} - reqest key of tx to listen.
- * @property apiHost {string} - host running Pact server
- * @return {object} - Object containing tx result from pact server
-*/
-const fetchListen = async function ({rk, apiHost}) {
-  const cmd = { "listen": rk }
-  const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(cmd));
->>>>>>> b4aa797beec41087871489310786570c91999f08
   const resJSON = await res.json();
   return resJSON.result;
 };

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -6,7 +6,7 @@
 
 const blake = require('blakejs');
 const nacl = require('tweetnacl');
-const base64url = require('base64-url')
+const base64url = require('base64-url');
 
 /**
  * Convert binary to hex.
@@ -21,7 +21,7 @@ var binToHex = function(s) {
   }
 
   return Buffer.from(s).toString('hex');
-};
+}
 
 /**
  * Convert hex string to binary.
@@ -31,28 +31,28 @@ var binToHex = function(s) {
 var hexToBin = function(h) {
   if (typeof h !== 'string') { throw new TypeError("Expected string: " + h); }
   return new Uint8Array(Buffer.from(h,'hex'));
-};
+}
 
 /**
  * Perform blake2b256 hashing.
  */
 var hashBin = function(s) {
   return blake.blake2b(s, null, 32);
-};
+}
 
 /**
  * Perform blake2b256 hashing, encoded as unescaped base64url.
  */
 var hash = function(s) {
   return base64UrlEncode(hashBin(s));
-};
+}
 
 /**
  * Hash string as unescaped base64url.
  */
 var base64UrlEncode = function(s) {
   return base64url.escape(base64url.encode(s));
-};
+}
 
 /**
  * Generate a random ED25519 keypair.
@@ -63,7 +63,7 @@ var genKeyPair = function() {
   var pubKey = binToHex(kp.publicKey);
   var secKey = binToHex(kp.secretKey).slice(0,64);
   return {"publicKey": pubKey, "secretKey": secKey};
-};
+}
 
 var toTweetNaclSecretKey = function(keyPair) {
   if (!keyPair.hasOwnProperty("publicKey") || !keyPair.hasOwnProperty("secretKey") ) {
@@ -72,7 +72,7 @@ var toTweetNaclSecretKey = function(keyPair) {
      JSON.stringify(keyPair));
   }
   return hexToBin(keyPair.secretKey + keyPair.publicKey);
-};
+}
 
 /**
  * Sign data using key pair.
@@ -88,14 +88,14 @@ var sign = function(msg, keyPair) {
   var hsh = base64UrlEncode(hshBin);
   var sigBin = nacl.sign.detached(hshBin, toTweetNaclSecretKey(keyPair));
   return {"hash": hsh, "sig": binToHex(sigBin), "pubKey":keyPair.publicKey};
-};
+}
 
 var pullSigAndPubKey = function(s) {
   if (!s.hasOwnProperty("pubKey") || !s.hasOwnProperty("sig")) {
     throw new TypeError("Expected to find keys of name 'sig' and 'pubKey' in " + JSON.stringify(s));
   }
   return {"sig":s.sig, "pubKey":s.pubKey};
-};
+}
 
 
 var pullSig = function(s) {
@@ -103,14 +103,14 @@ var pullSig = function(s) {
     throw new TypeError("Expected to find keys of name 'sig' in " + JSON.stringify(s));
   }
   return {"sig":s.sig};
-};
+}
 
 var pullPubKeyAndAddr = function(s) {
   if (!s.hasOwnProperty("pubKey")) {
     throw new TypeError("Expected to find keys of name 'pubKey' in " + JSON.stringify(s));
   }
   return {"pubKey":s.pubKey, "addr":s.pubKey, "scheme": "ED25519"};
-};
+}
 
 
 var pullAndCheckHashs = function(sigs) {
@@ -122,7 +122,7 @@ var pullAndCheckHashs = function(sigs) {
     }
   }
   return hsh;
-};
+}
 
 /**
  * Prepare an ExecMsg pact command for use in send or local execution.
@@ -155,7 +155,7 @@ var prepareExecCmd = function(keyPairs, nonce, pactCode, envData, meta) {
   var cmd = JSON.stringify(cmdJSON);
   var sigs = kpArray.map(function(kp) { return sign(cmd, kp); });
   return mkSingleCmd(sigs,cmd);
-};
+}
 
 /**
  * Makes a single command given signed data.
@@ -169,7 +169,7 @@ var mkSingleCmd = function(sigs, cmd) {
   return { "hash": pullAndCheckHashs(sigs)
            , "sigs": sigs.map(pullSig)
            , "cmd": cmd };
-};
+}
 
 /**
  * Makes outer wrapper for a 'send' endpoint.
@@ -177,7 +177,7 @@ var mkSingleCmd = function(sigs, cmd) {
  */
 var mkPublicSend = function(cmds) {
   return { "cmds": asArray(cmds) };
-};
+}
 
 /**
  * Make an ED25519 "signer" array element for inclusion in a Pact payload.
@@ -217,21 +217,14 @@ var enforceArray = function(val,msg) {
  */
 var simpleExecCommand = function(keyPairs, nonce, pactCode, envData, meta) {
   return mkPublicSend(prepareExecCmd(keyPairs, nonce, pactCode, envData, meta));
-};
-
-/**
- * Make a full 'local' endpoint exec command. See 'prepareExecCmd' for parameters.
- */
-var simpleLocalCommand = function(keyPairs, nonce, pactCode, envData, meta) {
-  return prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
-};
+}
 
 var unique = function(arr) {
   var n = {},r=[];
   for(var i = 0; i < arr.length; i++)
   var hsh = eckHashs(sigs);
   return mkPublicSend({"hash": hsh, "sigs":sigs.map(pullSigAndPubKey), "cmd":cmd});
-};
+}
 
 var unique = function(arr) {
   var n = {},r=[];
@@ -244,7 +237,7 @@ var unique = function(arr) {
     }
   }
   return r;
-};
+}
 
 /**
  * Given an exec 'send' message, prepare a message for 'poll' endpoint.
@@ -260,7 +253,7 @@ var simplePollRequestFromExec = function(execMsg) {
     rks = unique(cmds.map(function(v){return v.hash;}));
   }
   return {"requestKeys": rks};
-};
+}
 
 /**
  * Given an exec 'send' message, prepare a message for 'listen' endpoint.
@@ -276,7 +269,7 @@ var simpleListenRequestFromExec = function(execMsg) {
     rks = unique(cmds.map(function(v){return v.hash;}));
   }
   return {"listen": rks[0]};
-};
+}
 
 /**
  * Variadic function to form a lisp s-expression application.
@@ -285,7 +278,7 @@ var simpleListenRequestFromExec = function(execMsg) {
 var mkExp = function(pgmName) {
   enforceType(pgmName, "string", "pgmName")
   return '(' + pgmName + ' ' + Array.prototype.slice.call(arguments, 1).map(JSON.stringify).join(' ') + ')';
-};
+}
 
 /**
  * Prepare a chainweb-style meta payload.
@@ -300,8 +293,8 @@ var mkMeta = function (sender, chainId, gasPrice, gasLimit) {
   enforceType(chainId, "string", "chainId");
   enforceType(gasPrice, "number", "gasPrice");
   enforceType(gasPrice, "number", "gasLimit");
-  return {"gasLimit":gasLimit, "chainId":chainId, "gasPrice":gasPrice, "sender":sender}
-};
+  return { "gasLimit":gasLimit, "chainId":chainId, "gasPrice":gasPrice, "sender":sender }
+}
 
 /**
  * Formats ExecCmd into api request object
@@ -314,7 +307,7 @@ var mkReq = function (cmd) {
     method: 'POST',
     body: JSON.stringify(cmd),
   }
-};
+}
 
 /**
  * Sends Pact command to a running Pact server and retrieves tx result.
@@ -325,19 +318,18 @@ var mkReq = function (cmd) {
  * @property envData {object} - JSON message data for command, default at empty obj
  * @property meta {object} - meta information, see mkMeta
  * @property apiHost {string} - host running Pact server
- * @return {object} - tx result received from pact server.
+ * @return {object} - Request key of the tx received from pact server.
  */
-const sendCommand = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
+const fetchSend = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
   const reqParams = ["pactCode", "keyPairs", "apiHost"]
   reqParams.forEach(arg => {
     if (!arguments[0][arg]) throw new Error (`Pact.sendCommand(): No ${arg} provided`)
   })
   const cmd = simpleExecCommand(keyPairs, nonce, pactCode, envData, meta);
-  const res = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
-  const txRes = await fetch(`${apiHost}/api/v1/listen`, mkReq(simpleListenRequestFromExec(cmd)));
+  const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
   const tx = await txRes.json();
-  return tx.result;
-};
+  return tx;
+}
 
 /**
  * Sends Local Pact command to a running Pact server and retrieves local tx result.
@@ -350,16 +342,46 @@ const sendCommand = async function ({pactCode, keyPairs, nonce=new Date().toISOS
  * @property apiHost {string} - host running Pact server
  * @return {object} - tx result received from pact server.
  */
-const sendLocalCommand = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
+const fetchLocal = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
   const reqParams = ["pactCode", "keyPairs", "apiHost"]
   reqParams.forEach(arg => {
     if (!arguments[0][arg])  throw new Error (`Pact.sendCommand(): No ${arg} provided`)
   })
-  const cmd = simpleLocalCommand(keyPairs, nonce, pactCode, envData, meta);
+  const cmd = prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
   const txRes = await fetch(`${apiHost}/api/v1/local`, mkReq(cmd));
   const tx = await txRes.json();
   return tx.result;
-};
+}
+
+/**
+ * Request poll Pact command to a running Pact server and retrieves tx result.
+ * @param {Object}
+ * @property rks {array} - Array of request keys of tx to poll.
+ * @property apiHost {string} - host running Pact server
+ * @return {object} - Array of tx request keys and tx results from pact server.
+*/
+const fetchPoll = async function ({rks, apiHost}) {
+  const cmd = { "requestKeys": rks }
+  const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(cmd));
+  const resJSON = await res.json();
+  return Object.values(resJSON).map(res => {
+    return { reqKey: res.reqKey, result: res.result };
+  })
+}
+
+/**
+ * Request listen Pact command to a running Pact server and retrieves tx result.
+ * @param {Object}
+ * @property rk {string} - reqest key of tx to listen.
+ * @property apiHost {string} - host running Pact server
+ * @return {object} - Object containing tx result from pact server
+*/
+const fetchListen = async function ({rk, apiHost}) {
+  const cmd = { "listen": rk }
+  const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(cmd));
+  const resJSON = await res.json();
+  return resJSON.result;
+}
 
 module.exports = {
   crypto: {
@@ -374,7 +396,7 @@ module.exports = {
   api: {
     prepareExecCmd: prepareExecCmd,
     mkSingleCmd: mkSingleCmd,
-    mkPublicSend: mkPublicSend,
+    mkPublicSend: mkPublicSend
   },
   lang: {
     mkExp: mkExp,
@@ -383,11 +405,15 @@ module.exports = {
   simple: {
     exec: {
       createCommand: simpleExecCommand,
-      createLocalCommand: simpleLocalCommand,
+      createLocalCommand: prepareExecCmd,
       createPollRequest: simplePollRequestFromExec,
       createListenRequest: simpleListenRequestFromExec
     }
   },
-  sendCommand: sendCommand,
-  sendLocalCommand: sendLocalCommand
-};
+  fetch: {
+    send: fetchSend,
+    local: fetchLocal,
+    poll: fetchPoll,
+    listen: fetchListen
+  }
+}

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -151,7 +151,7 @@ var pullAndCheckHashs = function(sigs) {
  * @param meta {object} - meta information, see mkMeta
  * @return valid pact API command for send or local use.
  */
-var prepareExecCmd = function(keyPairs, nonce, pactCode, envData, meta) {
+var prepareExecCmd = function(keyPairs, nonce=new Date().toISOString(), pactCode, envData, meta=mkMeta("","",0,0)) {
   enforceType(nonce, "string", "nonce");
   enforceType(pactCode, "string", "pactCode");
 
@@ -375,58 +375,38 @@ var mkReq = function(cmd) {
 };
 
 /**
- * A Command Object
- * @typedef {Object} ExecCmd
- * @property pactCode {string} - pact code to execute
- * @property keyPairs {array or object} - array or single ED25519 keypair
- * @property nonce {string} - nonce value, default at current time
- * @property envData {object} - JSON message data for command, default at empty obj
- * @property meta {object} - meta information, see mkMeta
- * @property apiHost {string} - host running Pact server
+ * A Command Object to Execute in Pact Server.
+ * @typedef {Object} execCmd
+ * @property pactCode {string} pact code to execute
+ * @property keyPairs {array or object} array or single ED25519 keypair
+ * @property nonce {string} nonce value, default at current time
+ * @property envData {object} JSON message data for command, default at empty obj
+ * @property meta {object} meta information, see mkMeta
  */
 
 /**
  * Sends Pact command to a running Pact server and retrieves tx result.
- * @param {ExecCmd} SendCmd
- * @return {object} - Request key of the tx received from pact server.
+ * @param {[execCmd] or execCmd} sendCmd cmd or a list of cmd's to execute
+ * @param {string} apiHost host running Pact server
+ * @return {object} Request key of the tx received from pact server.
  */
-const fetchSend = async function({
-  pactCode,
-  keyPairs,
-  nonce = new Date().toISOString(),
-  envData = {},
-  meta = mkMeta("", "", 0, 0),
-  apiHost
-}) {
-  const reqParams = ["pactCode", "keyPairs", "apiHost"];
-  reqParams.forEach(arg => {
-    if (!arguments[0][arg])
-      throw new Error(`Pact.sendCommand(): No ${arg} provided`);
-  });
-  const cmd = simpleExecCommand(keyPairs, nonce, pactCode, envData, meta);
-  const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
+const fetchSend = async function(sendCmd, apiHost){
+  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  const sendCmds = asArray(sendCmd).map(cmd => prepareExecCmd(cmd.keyPairs, cmd.nonce, cmd.pactCode, cmd.envData, cmd.meta));
+  const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(mkPublicSend(sendCmds)));
   const tx = await txRes.json();
   return tx;
 };
 
 /**
- * Sends Local Pact command to a running Pact server and retrieves local tx result.
- * @param {ExecCmd} LocalCmd
- * @return {object} - tx result received from pact server.
+ * Sends Local Pact command to a local Pact server and retrieves local tx result.
+ * @param {execCmd} localCmd a single cmd to execute locally
+ * @param {string} apiHost host running Pact server
+ * @return {object} tx result received from pact server.
  */
-const fetchLocal = async function({
-  pactCode,
-  keyPairs,
-  nonce = new Date().toISOString(),
-  envData = {},
-  meta = mkMeta("", "", 0, 0),
-  apiHost
-}) {
-  const reqParams = ["pactCode", "keyPairs", "apiHost"];
-  reqParams.forEach(arg => {
-    if (!arguments[0][arg])
-      throw new Error(`Pact.sendCommand(): No ${arg} provided`);
-  });
+const fetchLocal = async function(localCmd, apiHost) {
+  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  const {keyPairs, nonce, pactCode, envData, meta} = localCmd
   const cmd = prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
   const txRes = await fetch(`${apiHost}/api/v1/local`, mkReq(cmd));
   const tx = await txRes.json();
@@ -435,14 +415,13 @@ const fetchLocal = async function({
 
 /**
  * Request poll Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
- * @property rks {array} - Array of request keys of tx to poll.
- * @property apiHost {string} - host running Pact server
- * @return {object} - Array of tx request keys and tx results from pact server.
+ * @param {{requestKeys: [<rk:string>]}} pollCmd request Keys of txs to poll.
+ * @param {string} apiHost host running Pact server
+ * @return {object} Array of tx request keys and tx results from pact server.
  */
-const fetchPoll = async function({ rks, apiHost }) {
-  const cmd = { requestKeys: rks };
-  const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(cmd));
+const fetchPoll = async function(pollCmd, apiHost) {
+  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  const res = await fetch(`${apiHost}/api/v1/poll`, mkReq(pollCmd));
   const resJSON = await res.json();
   return Object.values(resJSON).map(res => {
     return { reqKey: res.reqKey, result: res.result };
@@ -451,14 +430,13 @@ const fetchPoll = async function({ rks, apiHost }) {
 
 /**
  * Request listen Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
- * @property rk {string} - reqest key of tx to listen.
- * @property apiHost {string} - host running Pact server
- * @return {object} - Object containing tx result from pact server
+ * @param {{listenCmd: <rk:string>}} listenCmd reqest key of tx to listen.
+ * @param {string} apiHost host running Pact server
+ * @return {object} Object containing tx result from pact server
  */
-const fetchListen = async function({ rk, apiHost }) {
-  const cmd = { listen: rk };
-  const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(cmd));
+const fetchListen = async function(listenCmd, apiHost) {
+  if (!apiHost)  throw new Error(`Pact.fetch.send(): No apiHost provided`);
+  const res = await fetch(`${apiHost}/api/v1/listen`, mkReq(listenCmd));
   const resJSON = await res.json();
   return resJSON.result;
 };

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -212,12 +212,18 @@ var enforceArray = function(val,msg) {
   }
 }
 
-
 /**
  * Make a full 'send' endpoint exec command. See 'prepareExecCmd' for parameters.
  */
 var simpleExecCommand = function(keyPairs, nonce, pactCode, envData, meta) {
   return mkPublicSend(prepareExecCmd(keyPairs, nonce, pactCode, envData, meta));
+};
+
+/**
+ * Make a full 'local' endpoint exec command. See 'prepareExecCmd' for parameters.
+ */
+var simpleLocalCommand = function(keyPairs, nonce, pactCode, envData, meta) {
+  return prepareExecCmd(keyPairs, nonce, pactCode, envData, meta);
 };
 
 var unique = function(arr) {
@@ -329,6 +335,7 @@ module.exports = {
   simple: {
     exec: {
       createCommand: simpleExecCommand,
+      createLocalCommand: simpleLocalCommand,
       createPollRequest: simplePollRequestFromExec,
       createListenRequest: simpleListenRequestFromExec
     }

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -310,16 +310,21 @@ var mkReq = function (cmd) {
 }
 
 /**
- * Sends Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
+ * A Command Object to be received to send cmd to Pact server.
+ * @typedef {Object} execCmd
  * @property pactCode {string} - pact code to execute
  * @property keyPairs {array or object} - array or single ED25519 keypair
  * @property nonce {string} - nonce value, default at current time
  * @property envData {object} - JSON message data for command, default at empty obj
  * @property meta {object} - meta information, see mkMeta
  * @property apiHost {string} - host running Pact server
- * @return {object} - Request key of the tx received from pact server.
  */
+
+ /**
+  * Sends Pact command to a running Pact server and retrieves the tx's request key.
+  * @param {execCmd} sendCmd
+  * @return {object} - Request key of the tx received from pact server.
+  */
 const fetchSend = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
   const reqParams = ["pactCode", "keyPairs", "apiHost"]
   reqParams.forEach(arg => {
@@ -333,13 +338,7 @@ const fetchSend = async function ({pactCode, keyPairs, nonce=new Date().toISOStr
 
 /**
  * Sends Local Pact command to a running Pact server and retrieves local tx result.
- * @param {Object}
- * @property pactCode {string} - pact code to execute
- * @property keyPairs {array or object} - array or single ED25519 keypair
- * @property nonce {string} - nonce value, default at current time
- * @property envData {object} - JSON message data for command, default at empty obj
- * @property meta {object} - meta information, see mkMeta
- * @property apiHost {string} - host running Pact server
+ * @param {execCmd} localCmd
  * @return {object} - tx result received from pact server.
  */
 const fetchLocal = async function ({pactCode, keyPairs, nonce=new Date().toISOString(), envData={}, meta=mkMeta("","",0,0), apiHost}) {
@@ -355,7 +354,7 @@ const fetchLocal = async function ({pactCode, keyPairs, nonce=new Date().toISOSt
 
 /**
  * Request poll Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
+ * @param {Object} pollCmd
  * @property rks {array} - Array of request keys of tx to poll.
  * @property apiHost {string} - host running Pact server
  * @return {object} - Array of tx request keys and tx results from pact server.
@@ -371,7 +370,7 @@ const fetchPoll = async function ({rks, apiHost}) {
 
 /**
  * Request listen Pact command to a running Pact server and retrieves tx result.
- * @param {Object}
+ * @param {Object} listenCmd
  * @property rk {string} - reqest key of tx to listen.
  * @property apiHost {string} - host running Pact server
  * @return {object} - Object containing tx result from pact server

--- a/readme.md
+++ b/readme.md
@@ -44,25 +44,120 @@ A helper function for constructing native Pact commands.
 ```
 Pact.lang.mkExp(<string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
+
+Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: nunmber>, <gasLimit: number>) -> <meta: object>
+  ex: mkMeta("Bob", "Chain-1", 20, 30) -> { "sender": "Bob", "ChainId": "Chain-1", "gasPrice": 20, "gasLimit": 30 }
 ```
 
 NB: `JSON.stringify`, which is used here, generally converts floating point numbers correctly but fails for high precision scientific numbers < 0; you will need to manually convert them.
 e.g. `JSON.stringify(.0000001) -> '1e-7'` is incorrect as Pact has infinite precision decimals but does not interpret scientific numbers, so the proper conversion would be `JSON.stringify(.0000001) -> '0.0000001'`
 
 
-### Simple API
+
+### Simple API Fetch
+
+Simple fetch functions to make API request to a running Pact Server and retrieve the results.
+
+```
+* A Command Object to Execute in send or local.
+* @typedef {Object} execCmd
+* @property pactCode {string} - pact code to execute
+* @property keyPairs {array or object} - array or single ED25519 keypair
+* @property nonce {string} - nonce value, default at current time
+* @property envData {object} - JSON message data for command, default at empty obj
+* @property meta {object} - meta information, see mkMeta
+*/
+```
+```
+## Make API request to execute a command or commands in the public server and retrieve request keys of the txs.
+
+Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
+
+  ex:
+    const cmds = [{
+                    keyPairs: KEY_PAIR,
+                    pactCode: "todos.delete-todos "id-1""
+                  },{
+                    keyPairs: KEY_PAIR,
+                    pactCode: "todos.delete-todos "id-2""
+                  },{
+                    keyPairs: KEY_PAIR,
+                    pactCode: "todos.delete-todos "id-3""
+                  }]
+
+    Pact.fetch.send(cmds, API_HOST) -> { requestKeys: [
+                                          "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+                                          "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+                                          "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
+```
+```
+## Make API request to execute a single command in the local server and retrieve the result of the tx. (Used to execute commands that read DB)
+Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
+
+  ex:     
+    const cmd = {
+        keyPairs: KEY_PAIR,
+        pactCode: `(todos.read-todos)`
+      };
+
+    Pact.fetch.local(cmd, API_HOST) ->
+    { status: "success",
+       data: [{ id: "id-1"
+                title: "wash"
+                completed: false
+              }]
+    }
+```
+```
+## Make API request to retrieve result of a tx or multiple tx's with request keys.
+Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "...", result: {...}}, ...]
+
+  ex:
+    const cmd = { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+                                 "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+                                 "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
+
+    Pact.fetch.poll(cmd, API_HOST) -> [{ reqKey: "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM",
+                                         result: {
+                                           status: "success",
+                                           data: "Write succeeded"
+                                         }
+                                       },
+                                       { reqKey: "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+                                         result: {
+                                           status: "success",
+                                           data: "Write succeeded"
+                                         }
+                                       }]
+```
+```
+## Make API request to retrieve result of a tx with a request key.
+Pact.fetch.listen({listen: "..."}, <apiHost:string>) -> {status: "...", data: "..."}
+
+  ex:
+    const cmd = { listen: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE" }
+
+    Pact.fetch.listen(cmd, API_HOST) -> { status: "success",
+                                          data: "Write succeeded" }
+```
+
+
+### Simple API Command
 
 A simplified set of functions for working with the api.
 
 ```
-## send as POST to /api/send
+## Creates a command to send as POST to /api/send
 Pact.simple.exec.createCommand([keyPair], <nonce: string>, <pactCode: string>, <envData: object>) -> {"cmds":[...]}
 
-## send as POST to /api/poll
+## Creates a command to send as POST to /api/local
+Pact.simple.exec.createLocalRequest([keyPair], <nonce: string>, <pactCode: string>, <envData: object>) -> {"hash": "...", sigs: [...], cmd: {...} }
+
+## Creates a command to send as POST to /api/poll
 Pact.simple.exec.createPollRequest({"cmds": [...]}) -> {"requestKeys": [...]}
 
-## send as POST to /api/listen
-Pact.simple.exec.createListenRequest({"cmds": [...]}) -> {"requestKey": <string>}
+## Creates a command to send as POST to /api/listen
+Pact.simple.exec.createListenRequest({"cmds": [...]}) -> {"listen": <string>}
 ```
 
 ### Low Level API

--- a/readme.md
+++ b/readme.md
@@ -85,10 +85,12 @@ Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
                     pactCode: 'todos.delete-todos "id-3"'
                   }]
 
-    Pact.fetch.send(cmds, API_HOST) -> { requestKeys: [
-                                          "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-                                          "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
-                                          "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
+    Pact.fetch.send(cmds, API_HOST)
+
+    //Returns the following as a Promise Value
+    { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+                     "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+                     "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
 ```
 ```
 ## Make API request to execute a single command in the local server and retrieve the result of the tx. (Used to execute commands that read DB)
@@ -100,7 +102,9 @@ Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
         pactCode: `(todos.read-todos)`
       };
 
-    Pact.fetch.local(cmd, API_HOST) ->
+    Pact.fetch.local(cmd, API_HOST)
+
+    //Returns the following as a Promise Value
     { status: "success",
        data: [{ id: "id-1"
                 title: "wash"
@@ -116,18 +120,21 @@ Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "..."
     const cmd = { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
                                  "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0" ]}
 
-    Pact.fetch.poll(cmd, API_HOST) -> [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-                                         result: {
-                                           status: "success",
-                                           data: "Write succeeded"
-                                         }
-                                       },
-                                       { reqKey: "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
-                                         result: {
-                                           status: "success",
-                                           data: "Write succeeded"
-                                         }
-                                       }]
+    Pact.fetch.poll(cmd, API_HOST)
+
+    //Returns the following as a Promise Value
+    [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+       result: {
+         status: "success",
+         data: "Write succeeded"
+       }
+     },
+     { reqKey: "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+       result: {
+         status: "success",
+         data: "Write succeeded"
+       }
+     }]
 ```
 ```
 ## Make API request to retrieve result of a tx with a request key.
@@ -136,8 +143,11 @@ Pact.fetch.listen({listen: "..."}, <apiHost:string>) -> {status: "...", data: ".
   ex:
     const cmd = { listen: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE" }
 
-    Pact.fetch.listen(cmd, API_HOST) -> { status: "success",
-                                          data: "Write succeeded" }
+    Pact.fetch.listen(cmd, API_HOST)
+
+    //Returns the following as a Promise Value
+    { status: "success",
+      data: "Write succeeded" }
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -76,13 +76,13 @@ Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
   ex:
     const cmds = [{
                     keyPairs: KEY_PAIR,
-                    pactCode: "todos.delete-todos "id-1""
+                    pactCode: 'todos.delete-todos "id-1"'
                   },{
                     keyPairs: KEY_PAIR,
-                    pactCode: "todos.delete-todos "id-2""
+                    pactCode: 'todos.delete-todos "id-2"'
                   },{
                     keyPairs: KEY_PAIR,
-                    pactCode: "todos.delete-todos "id-3""
+                    pactCode: 'todos.delete-todos "id-3"'
                   }]
 
     Pact.fetch.send(cmds, API_HOST) -> { requestKeys: [
@@ -114,10 +114,9 @@ Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "..."
 
   ex:
     const cmd = { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-                                 "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
-                                 "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
+                                 "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0" ]}
 
-    Pact.fetch.poll(cmd, API_HOST) -> [{ reqKey: "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM",
+    Pact.fetch.poll(cmd, API_HOST) -> [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
                                          result: {
                                            status: "success",
                                            data: "Write succeeded"


### PR DESCRIPTION
Added following functions: 
 - simpleLocalCommand: 
       returns Pact command in JSON format of local API request. 
 - sendCommand: 
       makes request to /send, then requests to /listen, then returns responseJSON.result of listen. 
 - sendLocalCommand: 
       makes request to /local and returns responseJSON.result