### PR TITLE
Change fetch example and description of meta fields. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,14 @@ A helper function for constructing native Pact commands.
    * "ChainId" represents the Chain Id that the tx will be sent to.
    * "gasPrice" represents the gas price of the tx.
    * "gasLimit" represents the gas limit of the tx.
+   * "creationTime" represents the creation time of the tx (0 refers to current time).
+   * "ttl" represents the tx's time to live on chain. (in seconds)
 ```
 Pact.lang.mkExp(<function:string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
 
-Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: nunmber>, <gasLimit: number>) -> <meta: object>
-  ex: mkMeta("Bob", "Chain-1", 20, 30) -> { "sender": "Bob", "ChainId": "Chain-1", "gasPrice": 20, "gasLimit": 30 }
+Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: number>, <gasLimit: number>, <creationTime: number>, <ttl: number>) -> <meta: object>
+  ex: mkMeta("Bob", "1", 0.0001, 100, 0, 28800) -> { "sender": "Bob", "ChainId": "1", "gasPrice": 0.0001, "gasLimit": 100, "creationTime": 0, "ttl": 28800 }
 ```
 
 NB: `JSON.stringify`, which is used here, generally converts floating point numbers correctly but fails for high precision scientific numbers < 0; you will need to manually convert them.

--- a/readme.md
+++ b/readme.md
@@ -79,26 +79,26 @@ Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
                     keyPairs: KEY_PAIR,
                     pactCode: "(accounts.create-account 'account-1 (read-keyset 'account-keyset))",
                     envData: {
-                      "account-keyset": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"], 
+                      account-keyset: ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"], 
                     }
                   }, 
                   {
                     keyPairs: KEY_PAIR,
                     pactCode: "(accounts.create-account 'account2 (read-keyset 'account-keyset))",
                     envData: {
-                      "account-keyset": {
-                        "keys": [
-                            "2d70aa4f697c3a3b8dd6d97745ac074edcfd0eb65c37774cde25135483bea71e",
-                            "4c31dc9ee7f24177f78b6f518012a208326e2af1f37bb0a2405b5056d0cad628"
+                      account-keyset: {
+                        keys: [
+                          "2d70aa4f697c3a3b8dd6d97745ac074edcfd0eb65c37774cde25135483bea71e",
+                          "4c31dc9ee7f24177f78b6f518012a208326e2af1f37bb0a2405b5056d0cad628"
                         ],
-                        "pred": "keys-any"
+                        pred: "keys-any"
                       }
                     }
                   }]
 
     Pact.fetch.send(cmds, API_HOST)
 
-    //Returns the following as a Promise Value
+    // Returns the following as a Promise Value
     { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
                      "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0" ]}
 ```
@@ -114,17 +114,16 @@ Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
 
     Pact.fetch.local(cmd, API_HOST)
 
-    //Returns the following as a Promise Value
+    // Returns the following as a Promise Value
     { status: "success",
-      data: [{
-        { "keyset": {
-           "pred": "keys-all",
-           "keys": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]
-           },
-          "balance": 0
-        }
-       }]
-     }
+      data: { 
+        keyset: {
+           pred: "keys-all",
+           keys: ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]
+        },
+        balance: 0.0
+      }
+    }
 ```
 ```
 ## Make API request to retrieve result of a tx or multiple tx's with request keys.
@@ -136,7 +135,7 @@ Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "..."
 
     Pact.fetch.poll(cmd, API_HOST)
 
-    //Returns the following as a Promise Value
+    // Returns the following as a Promise Value
     [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
        result: {
          status: "success",
@@ -159,7 +158,7 @@ Pact.fetch.listen({listen: "..."}, <apiHost:string>) -> {status: "...", data: ".
 
     Pact.fetch.listen(cmd, API_HOST)
 
-    //Returns the following as a Promise Value
+    // Returns the following as a Promise Value
     { status: "success",
       data: "Write succeeded" }
 ```

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ A helper function for constructing native Pact commands.
 - `mkExp` takes in Pact function and its arguments and returns a Pact expression.
 - `mkMeta` returns meta information of the tx in object format. This is only important for the txs in public blockchain. txs don't need a meta field in private blockchain.
    * "sender" represents the gas account, and the tx must be signed with the keyset associated with the gas account. Otherwise, the tx will be rejected.
-   * "ChainId" represents the chain Id that the tx will be sent to.
+   * "chainId" represents the chain Id that the tx will be sent to.
    * "gasPrice" represents the gas price of the tx.
    * "gasLimit" represents the gas limit of the tx.
    * "creationTime" represents the tx's wait time to be considered a candidate for inclusion into a block in the blockchain. (in seconds)
@@ -53,7 +53,7 @@ Pact.lang.mkExp(<function:string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
 
 Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: number>, <gasLimit: number>, <creationTime: number>, <ttl: number>) -> <meta: object>
-  ex: mkMeta("Bob", "1", 0.0001, 100, 0, 28800) -> { "sender": "Bob", "ChainId": "1", "gasPrice": 0.0001, "gasLimit": 100, "creationTime": 0, "ttl": 28800 }
+  ex: mkMeta("Bob", "1", 0.0001, 100, 0, 28800) -> { "sender": "Bob", "chainId": "1", "gasPrice": 0.0001, "gasLimit": 100, "creationTime": 0, "ttl": 28800 }
 ```
 
 NB: `JSON.stringify`, which is used here, generally converts floating point numbers correctly but fails for high precision scientific numbers < 0; you will need to manually convert them.

--- a/readme.md
+++ b/readme.md
@@ -40,14 +40,14 @@ Pact.crypto.toTweetNaclSecretKey(keyPair) -> <Uint8Array>
 ### Language Expression Construction
 
 A helper function for constructing native Pact commands.
-- mkExp takes in Pact function and its arguments and returns a Pact expression.
-- mkMeta returns gas information of the tx in object format. This is only important for the txs in public blockchain. txs don't need gas in private blockchain.
+- `mkExp` takes in Pact function and its arguments and returns a Pact expression.
+- `mkMeta` returns meta information of the tx in object format. This is only important for the txs in public blockchain. txs don't need a meta field in private blockchain.
    * "sender" represents the gas account, and the tx must be signed with the keyset associated with the gas account. Otherwise, the tx will be rejected.
-   * "ChainId" represents the Chain Id that the tx will be sent to.
+   * "ChainId" represents the chain Id that the tx will be sent to.
    * "gasPrice" represents the gas price of the tx.
    * "gasLimit" represents the gas limit of the tx.
-   * "creationTime" represents the creation time of the tx (0 refers to current time).
-   * "ttl" represents the tx's time to live on chain. (in seconds)
+   * "creationTime" represents the tx's wait time to be considered a candidate for inclusion into a block in the blockchain. (in seconds)
+   * "ttl" represents the tx's maximum wait time to be considered a candidate for inclusion into a block in the blockchain. (in seconds)
 ```
 Pact.lang.mkExp(<function:string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
@@ -71,7 +71,7 @@ Simple fetch functions to make API request to a running Pact Server and retrieve
 * @property pactCode {string} - pact code to execute
 * @property keyPairs {array or object} - array or single ED25519 keypair
 * @property nonce {string} - nonce value, default at current time
-* @property envData {object} - JSON message data including keyset information, default at empty obj
+* @property envData {object} - JSON message data including keyset information, defaults to empty obj
 * @property meta {object} - meta information, see mkMeta
 */
 ```

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,11 @@ Pact.crypto.toTweetNaclSecretKey(keyPair) -> <Uint8Array>
 
 A helper function for constructing native Pact commands.
 - mkExp takes in Pact function and its arguments and returns a Pact expression.
-- mkMeta returns an object of metadata of the tx. "sender" represents the gas account, "ChainId" represents the Chain Id, "gasPrice" represents the price of gas, and "gasLimit" represents the limit of gas.
+- mkMeta returns gas information of the tx in object format. This is only important for the txs in public blockchain. txs don't need gas in private blockchain.
+   * "sender" represents the gas account, and the tx must be signed with the keyset associated with the gas account. Otherwise, the tx will be rejected.
+   * "ChainId" represents the Chain Id that the tx will be sent to.
+   * "gasPrice" represents the gas price of the tx.
+   * "gasLimit" represents the gas limit of the tx.
 ```
 Pact.lang.mkExp(<function:string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
@@ -81,9 +85,9 @@ Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
                      keyPairs: KEY_PAIR,
                      pactCode: "(accounts.create-account 'account-1 (read-keyset 'account-keyset))",
                      envData: {
-                       "account-keyset": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"], 
+                       "account-keyset": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"],
                      }
-                  }, 
+                  },
                   // create an account with multi-sig keyset
                   {
                     keyPairs: KEY_PAIR,
@@ -120,7 +124,7 @@ Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
 
     // Returns the following as a Promise Value
     { "status": "success",
-      "data": { 
+      "data": {
         "keyset": {
            "pred": "keys-all",
            "keys": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]

--- a/readme.md
+++ b/readme.md
@@ -40,18 +40,13 @@ Pact.crypto.toTweetNaclSecretKey(keyPair) -> <Uint8Array>
 ### Language Expression Construction
 
 A helper function for constructing native Pact commands.
-- mkExp takes in Pact function and its arguments and returns a Pact expression.
-- mkMeta returns gas information of the tx in object format. This is only important for the txs in public blockchain. txs don't need gas in private blockchain.
-   * "sender" represents the gas account, and the tx must be signed with the keyset associated with the gas account. Otherwise, the tx will be rejected.
-   * "ChainId" represents the Chain Id that the tx will be sent to.
-   * "gasPrice" represents the gas price of the tx.
-   * "gasLimit" represents the gas limit of the tx.
+
 ```
-Pact.lang.mkExp(<function:string>, *args) -> <string>
+Pact.lang.mkExp(<string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
 
-Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: nunmber>, <gasLimit: number>) -> <meta: object>
-  ex: mkMeta("Bob", "Chain-1", 20, 30) -> { "sender": "Bob", "ChainId": "Chain-1", "gasPrice": 20, "gasLimit": 30 }
+Pact.lang.mkMeta(<sender:string> , <chainId:string>, <gasPrice: number>, <gasLimit: number>, <creationTime: number>, <ttl: number>) -> <meta: object>
+  ex: mkMeta("Bob", "1", 0.001, 100, 0, 28800) -> { "sender": "Bob", "ChainId": "1", "gasPrice": 0.001, "gasLimit": 100, "creationTime": 0, "ttl": 28800 }
 ```
 
 NB: `JSON.stringify`, which is used here, generally converts floating point numbers correctly but fails for high precision scientific numbers < 0; you will need to manually convert them.
@@ -69,7 +64,7 @@ Simple fetch functions to make API request to a running Pact Server and retrieve
 * @property pactCode {string} - pact code to execute
 * @property keyPairs {array or object} - array or single ED25519 keypair
 * @property nonce {string} - nonce value, default at current time
-* @property envData {object} - JSON message data including keyset information, default at empty obj
+* @property envData {object} - JSON message data for command, default at empty obj
 * @property meta {object} - meta information, see mkMeta
 */
 ```
@@ -79,36 +74,23 @@ Simple fetch functions to make API request to a running Pact Server and retrieve
 Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
 
   ex:
-    const cmds = [
-                  // create an account with single-sig keyset
-                  {
-                     keyPairs: KEY_PAIR,
-                     pactCode: "(accounts.create-account 'account-1 (read-keyset 'account-keyset))",
-                     envData: {
-                       "account-keyset": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"],
-                     }
-                  },
-                  // create an account with multi-sig keyset
-                  {
+    const cmds = [{
                     keyPairs: KEY_PAIR,
-                    pactCode: "(accounts.create-account 'account2 (read-keyset 'account-keyset))",
-                    envData: {
-                      "account-keyset": {
-                        "keys": [
-                          "2d70aa4f697c3a3b8dd6d97745ac074edcfd0eb65c37774cde25135483bea71e",
-                          "4c31dc9ee7f24177f78b6f518012a208326e2af1f37bb0a2405b5056d0cad628"
-                        ],
-                        "pred": "keys-any"
-                      }
-                    }
-                  }
-                 ]
+                    pactCode: 'todos.delete-todos "id-1"'
+                  },{
+                    keyPairs: KEY_PAIR,
+                    pactCode: 'todos.delete-todos "id-2"'
+                  },{
+                    keyPairs: KEY_PAIR,
+                    pactCode: 'todos.delete-todos "id-3"'
+                  }]
 
     Pact.fetch.send(cmds, API_HOST)
 
-    // Returns the following as a Promise Value
-    { "requestKeys": [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-                     "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0" ]}
+    //Returns the following as a Promise Value
+    { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+                     "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+                     "qqhiEAuerIBrkZArSXPZxybQLzkTzHcwiB4ZrRU7FJM" ]}
 ```
 ```
 ## Make API request to execute a single command in the local server and retrieve the result of the tx. (Used to execute commands that read DB)
@@ -117,20 +99,17 @@ Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
   ex:     
     const cmd = {
         keyPairs: KEY_PAIR,
-        pactCode: `(accounts.read-account 'account1)`
+        pactCode: `(todos.read-todos)`
       };
 
     Pact.fetch.local(cmd, API_HOST)
 
-    // Returns the following as a Promise Value
-    { "status": "success",
-      "data": {
-        "keyset": {
-           "pred": "keys-all",
-           "keys": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]
-        },
-        "balance": 0.0
-      }
+    //Returns the following as a Promise Value
+    { status: "success",
+       data: [{ id: "id-1"
+                title: "wash"
+                completed: false
+              }]
     }
 ```
 ```
@@ -143,17 +122,17 @@ Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "..."
 
     Pact.fetch.poll(cmd, API_HOST)
 
-    // Returns the following as a Promise Value
-    [{ "reqKey": "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-       "result": {
-         "status": "success",
-         "data": "Write succeeded"
+    //Returns the following as a Promise Value
+    [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+       result: {
+         status: "success",
+         data: "Write succeeded"
        }
      },
-     { "reqKey": "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
-       "result": {
-         "status": "success",
-         "data": "Write succeeded"
+     { reqKey: "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+       result: {
+         status: "success",
+         data: "Write succeeded"
        }
      }]
 ```
@@ -166,9 +145,9 @@ Pact.fetch.listen({listen: "..."}, <apiHost:string>) -> {status: "...", data: ".
 
     Pact.fetch.listen(cmd, API_HOST)
 
-    // Returns the following as a Promise Value
-    { "status": "success",
-      "data": "Write succeeded" }
+    //Returns the following as a Promise Value
+    { status: "success",
+      data: "Write succeeded" }
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Pact.crypto.toTweetNaclSecretKey(keyPair) -> <Uint8Array>
 
 A helper function for constructing native Pact commands.
 - mkExp takes in Pact function and its arguments and returns a Pact expression.
-- mkMeta returns an object of metadata of the tx. "sender" represents the gas account, "ChainId" represents the Chain Id, gasPrice represents the price of gas, and gasLimit represents the limit of gas.
+- mkMeta returns an object of metadata of the tx. "sender" represents the gas account, "ChainId" represents the Chain Id, "gasPrice" represents the price of gas, and "gasLimit" represents the limit of gas.
 ```
 Pact.lang.mkExp(<function:string>, *args) -> <string>
   ex: mkExp("todos.edit-todo", 1, "bar") -> '(todos.edit-todo 1 "bar")'
@@ -75,31 +75,35 @@ Simple fetch functions to make API request to a running Pact Server and retrieve
 Pact.fetch.send([<execCmd:object>], <apiHost:string>) -> {"requestKeys": [...]}
 
   ex:
-    const cmds = [{
-                    keyPairs: KEY_PAIR,
-                    pactCode: "(accounts.create-account 'account-1 (read-keyset 'account-keyset))",
-                    envData: {
-                      account-keyset: ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"], 
-                    }
+    const cmds = [
+                  // create an account with single-sig keyset
+                  {
+                     keyPairs: KEY_PAIR,
+                     pactCode: "(accounts.create-account 'account-1 (read-keyset 'account-keyset))",
+                     envData: {
+                       "account-keyset": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"], 
+                     }
                   }, 
+                  // create an account with multi-sig keyset
                   {
                     keyPairs: KEY_PAIR,
                     pactCode: "(accounts.create-account 'account2 (read-keyset 'account-keyset))",
                     envData: {
-                      account-keyset: {
-                        keys: [
+                      "account-keyset": {
+                        "keys": [
                           "2d70aa4f697c3a3b8dd6d97745ac074edcfd0eb65c37774cde25135483bea71e",
                           "4c31dc9ee7f24177f78b6f518012a208326e2af1f37bb0a2405b5056d0cad628"
                         ],
-                        pred: "keys-any"
+                        "pred": "keys-any"
                       }
                     }
-                  }]
+                  }
+                 ]
 
     Pact.fetch.send(cmds, API_HOST)
 
     // Returns the following as a Promise Value
-    { requestKeys: [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+    { "requestKeys": [ "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
                      "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0" ]}
 ```
 ```
@@ -115,13 +119,13 @@ Pact.fetch.local(<execCmd:object>, <apiHost:string>) -> {result}
     Pact.fetch.local(cmd, API_HOST)
 
     // Returns the following as a Promise Value
-    { status: "success",
-      data: { 
-        keyset: {
-           pred: "keys-all",
-           keys: ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]
+    { "status": "success",
+      "data": { 
+        "keyset": {
+           "pred": "keys-all",
+           "keys": ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"]
         },
-        balance: 0.0
+        "balance": 0.0
       }
     }
 ```
@@ -136,16 +140,16 @@ Pact.fetch.poll({requestKeys: ["..."]}, <apiHost:string>) -> [{requestKey: "..."
     Pact.fetch.poll(cmd, API_HOST)
 
     // Returns the following as a Promise Value
-    [{ reqKey: "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
-       result: {
-         status: "success",
-         data: "Write succeeded"
+    [{ "reqKey": "6ue-lrwXaLcDyxDwJ1nuLzOfFtnQ2TaF0_Or_X0KnbE",
+       "result": {
+         "status": "success",
+         "data": "Write succeeded"
        }
      },
-     { reqKey: "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
-       result: {
-         status: "success",
-         data: "Write succeeded"
+     { "reqKey": "P7qDsrt3evfEjtlQAW_b1ZPS7LpAZynCO8wx99hc5i0",
+       "result": {
+         "status": "success",
+         "data": "Write succeeded"
        }
      }]
 ```
@@ -159,8 +163,8 @@ Pact.fetch.listen({listen: "..."}, <apiHost:string>) -> {status: "...", data: ".
     Pact.fetch.listen(cmd, API_HOST)
 
     // Returns the following as a Promise Value
-    { status: "success",
-      data: "Write succeeded" }
+    { "status": "success",
+      "data": "Write succeeded" }
 ```
 
 


### PR DESCRIPTION
- Added description of mkExp and mkMeta fields (sender, ChainId, gasLimit, gasPrice)
- Changed fetch.send example to one that saves keyset by reading from envData. 