### PR TITLE
restoreKeyPairFromSecretKey

### DIFF
--- a/pact-lang-api-global.min.js
+++ b/pact-lang-api-global.min.js
@@ -901,6 +901,12 @@ function from (value, encodingOrOffset, length) {
     return fromArrayBuffer(value, encodingOrOffset, length)
   }
 
+  if (typeof SharedArrayBuffer !== 'undefined' &&
+      (isInstance(value, SharedArrayBuffer) ||
+      (value && isInstance(value.buffer, SharedArrayBuffer)))) {
+    return fromArrayBuffer(value, encodingOrOffset, length)
+  }
+
   if (typeof value === 'number') {
     throw new TypeError(
       'The "value" argument must not be of type number. Received type number'
@@ -5137,6 +5143,20 @@ var genKeyPair = function() {
   return { publicKey: pubKey, secretKey: secKey };
 };
 
+/**
+ * Generate a deterministic ED25519 keypair from a given Kadena secretKey
+ * @return {object} with "publicKey" and "secretKey" fields.
+ */
+var restoreKeyPairFromSecretKey = function(seed) {
+  if (!seed)  throw new Error(`seed for KeyPair generation not provided`);
+  if (seed.length !== 64) throw new Error('Seed for KeyPair generation has bad size');
+  var seedForNacl = hexToBin(seed);
+  var kp = nacl.sign.keyPair.fromSeed(seedForNacl);
+  var pubKey = binToHex(kp.publicKey);
+  var secKey = binToHex(kp.secretKey).slice(0, 64);
+  return { publicKey: pubKey, secretKey: secKey };
+};
+
 var toTweetNaclSecretKey = function(keyPair) {
   if (
     !keyPair.hasOwnProperty("publicKey") ||
@@ -5677,6 +5697,7 @@ module.exports = {
     base64UrlEncode: base64UrlEncode,
     hash: hash,
     genKeyPair: genKeyPair,
+    restoreKeyPairFromSecretKey: restoreKeyPairFromSecretKey,
     sign: sign,
     toTweetNaclSecretKey: toTweetNaclSecretKey
   },

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -68,6 +68,20 @@ var genKeyPair = function() {
   return { publicKey: pubKey, secretKey: secKey };
 };
 
+/**
+ * Generate a deterministic ED25519 keypair from a given Kadena secretKey
+ * @return {object} with "publicKey" and "secretKey" fields.
+ */
+var restoreKeyPairFromSecretKey = function(seed) {
+  if (!seed)  throw new Error(`seed for KeyPair generation not provided`);
+  if (seed.length !== 64) throw new Error('Seed for KeyPair generation has bad size');
+  var seedForNacl = hexToBin(seed);
+  var kp = nacl.sign.keyPair.fromSeed(seedForNacl);
+  var pubKey = binToHex(kp.publicKey);
+  var secKey = binToHex(kp.secretKey).slice(0, 64);
+  return { publicKey: pubKey, secretKey: secKey };
+};
+
 var toTweetNaclSecretKey = function(keyPair) {
   if (
     !keyPair.hasOwnProperty("publicKey") ||
@@ -608,6 +622,7 @@ module.exports = {
     base64UrlEncode: base64UrlEncode,
     hash: hash,
     genKeyPair: genKeyPair,
+    restoreKeyPairFromSecretKey: restoreKeyPairFromSecretKey,
     sign: sign,
     toTweetNaclSecretKey: toTweetNaclSecretKey
   },

--- a/pact-lang-api.min.js
+++ b/pact-lang-api.min.js
@@ -901,6 +901,12 @@ function from (value, encodingOrOffset, length) {
     return fromArrayBuffer(value, encodingOrOffset, length)
   }
 
+  if (typeof SharedArrayBuffer !== 'undefined' &&
+      (isInstance(value, SharedArrayBuffer) ||
+      (value && isInstance(value.buffer, SharedArrayBuffer)))) {
+    return fromArrayBuffer(value, encodingOrOffset, length)
+  }
+
   if (typeof value === 'number') {
     throw new TypeError(
       'The "value" argument must not be of type number. Received type number'
@@ -5132,6 +5138,20 @@ var genKeyPair = function() {
   return { publicKey: pubKey, secretKey: secKey };
 };
 
+/**
+ * Generate a deterministic ED25519 keypair from a given Kadena secretKey
+ * @return {object} with "publicKey" and "secretKey" fields.
+ */
+var restoreKeyPairFromSecretKey = function(seed) {
+  if (!seed)  throw new Error(`seed for KeyPair generation not provided`);
+  if (seed.length !== 64) throw new Error('Seed for KeyPair generation has bad size');
+  var seedForNacl = hexToBin(seed);
+  var kp = nacl.sign.keyPair.fromSeed(seedForNacl);
+  var pubKey = binToHex(kp.publicKey);
+  var secKey = binToHex(kp.secretKey).slice(0, 64);
+  return { publicKey: pubKey, secretKey: secKey };
+};
+
 var toTweetNaclSecretKey = function(keyPair) {
   if (
     !keyPair.hasOwnProperty("publicKey") ||
@@ -5672,6 +5692,7 @@ module.exports = {
     base64UrlEncode: base64UrlEncode,
     hash: hash,
     genKeyPair: genKeyPair,
+    restoreKeyPairFromSecretKey: restoreKeyPairFromSecretKey,
     sign: sign,
     toTweetNaclSecretKey: toTweetNaclSecretKey
   },

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,11 @@ Pact.crypto.sign(<string>, keyPair) -> {"hash": <string>, "sig":<string>, "pubKe
 Pact.crypto.toTweetNaclSecretKey(keyPair) -> <Uint8Array>
 ```
 
+Restoring a key pair from secret key.
+```
+Pact.crypto.restoreKeyPairFromSecretKey(secretKey) -> {"publicKey": <string>, "secretKey": <string>}
+```
+
 ### Language Expression Construction
 
 A helper function for constructing native Pact commands.

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -92,3 +92,16 @@ test("Takes in kp Object and returns secretkey in Uint8Array", function(t){
   t.deepEqual(actual, expected)
   t.end()
 })
+
+// test Pact.crypto.restoreKeyPairFromSecretKey()
+test('Takes in a secretKey - hex of length 64 representing 32 byte Uint8Array binary object and outputs generated keypair object of secretKey and publicKey', function (t) {
+  var secretKey = "53d1e1639bd6c607d33f3efcbaafc6d0d4fb022cd57a3a9b8534ddcd8c471902"
+  var actual = Pact.crypto.restoreKeyPairFromSecretKey(secretKey)
+  var expected = {
+    publicKey: '85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd',
+    secretKey: '53d1e1639bd6c607d33f3efcbaafc6d0d4fb022cd57a3a9b8534ddcd8c471902'
+  }
+
+  t.deepEqual(expected, actual);
+  t.end();
+});


### PR DESCRIPTION
This PR adds restoreKeyPairFromSecretKey function allowing to obtain a keyPair (mainly we need publicKey) from a given secretKey. 
The purpose is that wallets, like ZelCore, need to be able to use deterministic derivation of keypairs without storing any values. This method allows wallets use their own secretKey obtaining the needed publicKey respecting derivation path.
In background nacl.sign.keyPair.fromSeed is used.
Test provided.