### PR TITLE
upgrade chainweb.js to new minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "blakejs": "^1.0.1",
     "browserify": "^16.5.1",
-    "chainweb": "^2.0.0",
+    "chainweb": "^2.0.1",
     "node-fetch": "^2.6.6",
     "tweetnacl": "^0.14.5"
   },


### PR DESCRIPTION
Once https://github.com/kadena-io/chainweb.js/pull/1 is merged, please upgrade pact-lang-api as well

Signed-off-by: Will Martino <1953196+buckie@users.noreply.github.com>