### PR TITLE
upgrading chainweb.js to 2.0.2 for webpack 4 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pact-lang-api",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "JS API for Pact on Kadena Chainweb",
   "main": "pact-lang-api.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "dependencies": {
     "blakejs": "^1.0.1",
     "browserify": "^16.5.1",
-    "chainweb": "^2.0.1",
+    "chainweb": "^2.0.2",
     "node-fetch": "^2.6.6",
     "tweetnacl": "^0.14.5"
   },


### PR DESCRIPTION
After https://github.com/kadena-io/chainweb.js/pull/2 is merged and published, we need to pull in the new version.

Signed-off-by: Will Martino <1953196+buckie@users.noreply.github.com>