### PR TITLE
Version bump to 4.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pact-lang-api",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "JS API for Pact on Kadena Chainweb",
   "main": "pact-lang-api.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "dependencies": {
     "blakejs": "^1.0.1",
     "browserify": "^16.5.1",
-    "chainweb": "^2.0.2",
+    "chainweb": "^2.0.3",
     "node-fetch": "^2.6.6",
     "tweetnacl": "^0.14.5"
   },


### PR DESCRIPTION
Upgrades `chainweb.js` from 2.0.2 to 2.0.3