### PR TITLE
Implemented verifySig wrapper

### DIFF
--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -241,6 +241,21 @@ var signHash = function(hsh, keyPair) {
   return { hash: hsh, sig: binToHex(sigBin), pubKey: keyPair.publicKey };
 };
 
+/**
+ * Verify a signature
+ * @param msg - Message that was signed
+ * @param sig - Signature
+ * @param publicKey - Public key that signed the message
+ * @return {bool} True if signature is valid, false otherwise
+ */
+ var verifySig = function(msg, sig, publicKey) {
+  return nacl.sign.detached.verify(
+    hashBin(msg),
+    hexToBin(sig),
+    hexToBin(publicKey)
+  );
+};
+
 var pullSig = function(s) {
   if (!s.hasOwnProperty("sig")) {
     throw new TypeError(
@@ -840,7 +855,7 @@ module.exports = {
     restoreKeyPairFromSecretKey: restoreKeyPairFromSecretKey,
     sign: sign,
     signHash: signHash,
-    verifySig: nacl.sign.detached.verify,
+    verifySig: verifySig,
     toTweetNaclSecretKey: toTweetNaclSecretKey
   },
   api: {

--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -248,7 +248,7 @@ var signHash = function(hsh, keyPair) {
  * @param publicKey - Public key that signed the message
  * @return {bool} True if signature is valid, false otherwise
  */
- var verifySig = function(msg, sig, publicKey) {
+ var verifySignature = function(msg, sig, publicKey) {
   return nacl.sign.detached.verify(
     hashBin(msg),
     hexToBin(sig),
@@ -855,7 +855,8 @@ module.exports = {
     restoreKeyPairFromSecretKey: restoreKeyPairFromSecretKey,
     sign: sign,
     signHash: signHash,
-    verifySig: verifySig,
+    verifySig: nacl.sign.detached.verify,
+    verifySignature: verifySignature,
     toTweetNaclSecretKey: toTweetNaclSecretKey
   },
   api: {

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -77,12 +77,12 @@ test("Takes in cmd and keypair, returns object with hash and signature", functio
   t.end()
 })
 
-// test Pact.crypto.verifySign()
-test("Takes in hash and keypair, returns object with hash and signature", function(t) {
+// test Pact.crypto.verifySignature()
+test("Takes in message, signature and public key, returns true if signature is valid, false otherwise", function(t) {
   var msg = JSON.stringify(cmd);
   var result = Pact.crypto.sign(msg, kp);
-  var actual = Pact.crypto.verifySig(msg, result.sig, kp.publicKey);
-  var expected = true
+  var actual = Pact.crypto.verifySignature(msg, result.sig, kp.publicKey);
+  var expected = true;
 
   t.equals(actual, expected);
   t.end();

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -68,14 +68,25 @@ test("Takes in cmd and keypair, returns object with hash and signature", functio
 
   var actual = Pact.crypto.sign(JSON.stringify(cmd), kp);
   var expected = {
-   hash: 'uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8',
-   sig: '4b0ecfbb0e8f3cb291b57abd27028ceaa221950affa39f10efbf4a5fe740d32670e94c3d3949a7e5f4f6ea692052ca110f7cb2e9a8ee2c5eff4251ed84bbfa03',
-   pubKey: 'ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d'
- }
+    hash: 'uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8',
+    sig: '4b0ecfbb0e8f3cb291b57abd27028ceaa221950affa39f10efbf4a5fe740d32670e94c3d3949a7e5f4f6ea692052ca110f7cb2e9a8ee2c5eff4251ed84bbfa03',
+    pubKey: 'ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d'
+  }
 
   t.deepEqual(actual, expected)
   t.end()
 })
+
+// test Pact.crypto.verifySign()
+test("Takes in hash and keypair, returns object with hash and signature", function(t) {
+  var msg = JSON.stringify(cmd);
+  var result = Pact.crypto.sign(msg, kp);
+  var actual = Pact.crypto.verifySig(msg, result.sig, kp.publicKey);
+  var expected = true
+
+  t.equals(actual, expected);
+  t.end();
+});
 
 // test Pact.crypto.signHash()
 test("Takes in hash and keypair, returns object with hash and signature", function(t){


### PR DESCRIPTION
`Pact.crypto.verifySig` was the default `nacl.sign.detached.verify` implementation which takes the parameters in a different format compared to what what `Pact.crypto.sign` returns. 
Specifically `sig` and `publicKey` have to be `Uint8Array` while `msg` has to be hashed with blake2b256.