### PR TITLE
Add 'var' keyword to b64url function declaration

### DIFF
--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -36,7 +36,7 @@ var hexToBin = function(h) {
   return new Uint8Array(Buffer.from(h, "hex"));
 };
 
-b64url = (function() {
+var b64url = (function() {
 
   'use strict';
 


### PR DESCRIPTION
Not having it would cause the function to be declared in global scope.
Furthermore, in 'use strict' instances the package would fail completely