### PR TITLE
Fix package fails when Buffer is not provided globally

### DIFF
--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -8,6 +8,7 @@ const blake = require("blakejs");
 const nacl = require("tweetnacl");
 const fetch = require("node-fetch");
 const chainweb = require("chainweb");
+const Buffer = require("buffer").Buffer;
 
 /**
  * Convert binary to hex.


### PR DESCRIPTION
Currently the package relies on the Buffer object to be present, which isn't always the case.
While browserify is listed as a dependency that can provide Buffer, it is not used here.
Explicitly importing the package fixes this.