### PR TITLE
Parse `sendSigned` response via `parseRes` instead of `json()`

### DIFF
--- a/pact-lang-api.js
+++ b/pact-lang-api.js
@@ -834,9 +834,7 @@ const sendSigned = async function (signedCmd, apiHost) {
   const cmd = {
     "cmds": [ signedCmd ]
   }
-  const txRes = await fetch(`${apiHost}/api/v1/send`, mkReq(cmd));
-  const tx = await txRes.json();
-  return tx;
+  return parseRes(fetch(`${apiHost}/api/v1/send`, mkReq(cmd)));
 }
 
 module.exports = {


### PR DESCRIPTION
This fixes the response not being passed when in text format, showing instead as an "SyntaxError: Unexpected token..." error